### PR TITLE
Use `configureEach` on the TaskCollection when available for task config avoidance

### DIFF
--- a/gradle-runner-agent/src/main/scripts/init.gradle
+++ b/gradle-runner-agent/src/main/scripts/init.gradle
@@ -834,9 +834,10 @@ class TestTaskWrapper {
       }
     } else {
       // Fallback
-      taskCollection
-          .collect { new TestTaskWrapper(it) }
-          .each(action)
+      taskCollection.all { task ->
+        TestTaskWrapper wrapper = new TestTaskWrapper(task)
+        action(wrapper)
+      }
     }
   }
 }

--- a/gradle-runner-agent/src/main/scripts/init.gradle
+++ b/gradle-runner-agent/src/main/scripts/init.gradle
@@ -35,19 +35,6 @@ initscript {
   }
 }
 
-def forAllTestTasks(TaskCollection taskCollection, Closure action) {
-  if (taskCollection.metaClass.respondsTo(taskCollection, 'configureEach')) {
-    taskCollection.configureEach { task ->
-      TestTaskWrapper wrapper = new TestTaskWrapper(task)
-      action(wrapper)
-    }
-  } else {
-    taskCollection
-      .collect { new TestTaskWrapper(it) }
-      .each(action)
-  }
-}
-
 public class DependencyBasedTestRun {
 
   def logger
@@ -169,7 +156,7 @@ public class TeamcityPropertiesListener implements ProjectEvaluationListener {
   private void loadTestJvmArgs(Project project) {
     final String jvmargs = (String) project.teamcity["gradle.test.jvmargs"]
     final String[] arguments = jvmargs == null ? new String[0] : jvmargs.split("\n")
-    forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper task ->
+    TestTaskWrapper.forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper task ->
       task.setTmpDirectory(project.teamcity["teamcity.build.tempDir"]).jvmArgs(arguments)
     }
   }
@@ -811,7 +798,10 @@ class TestTaskWrapper {
   }
   private final def testTask
 
-  TestTaskWrapper(def testTask) { this.testTask = testTask }
+  /**
+   * Use {@link TestTaskWrapper#forAllTestTasks} to instantiate this object correctly.
+   */
+  private TestTaskWrapper(def testTask) { this.testTask = testTask }
   void addTestListener(def listener) { testTask.addTestListener(listener) }
   void addTestOutputListener(def listener) { testTask.addTestOutputListener(listener) }
   Project getProject() { testTask.project }
@@ -821,12 +811,33 @@ class TestTaskWrapper {
     }
     return this
   }
+
   TestTaskWrapper setTmpDirectory(String path) {
     if (testTask instanceof Test &&
         path != null && path != "") {
       testTask.systemProperty("java.io.tmpdir", path)
     }
     return this
+  }
+
+  /**
+   * Creates an instance of the {@link TestTaskWrapper} for every instance of the Test in the TaskCollection.
+   * Attempts to lazily evaluate the Closure action against all instances lazily if the version of Gradle supports it.
+   */
+  static void forAllTestTasks(TaskCollection taskCollection, Closure action) {
+    if (taskCollection.metaClass.respondsTo(taskCollection, 'configureEach')) {
+      // Use lazy task configuration:
+      // https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
+      taskCollection.configureEach { task ->
+        TestTaskWrapper wrapper = new TestTaskWrapper(task)
+        action(wrapper)
+      }
+    } else {
+      // Fallback
+      taskCollection
+          .collect { new TestTaskWrapper(it) }
+          .each(action)
+    }
   }
 }
 
@@ -847,7 +858,7 @@ gradle.useLogger(new TeamcityTaskListener(logger, isParallelExec))
 gradle.projectsEvaluated { Gradle gradle ->
   new DependencyBasedTestRun(logger).configureGradle(gradle)
   gradle.rootProject.allprojects { Project project ->
-    forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper testTask ->
+    TestTaskWrapper.forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper testTask ->
       def testListener = new TeamcityTestListener(logger, testTask, isParallelExec, project, testCounter)
       testTask.addTestListener(testListener.testListenerDelegate as TestListener)
       if (testOutputListenerClass != null) {

--- a/gradle-runner-agent/src/main/scripts/init.gradle
+++ b/gradle-runner-agent/src/main/scripts/init.gradle
@@ -35,6 +35,19 @@ initscript {
   }
 }
 
+def forAllTestTasks(TaskCollection taskCollection, Closure action) {
+  if (taskCollection.metaClass.respondsTo(taskCollection, 'configureEach')) {
+    taskCollection.configureEach { task ->
+      TestTaskWrapper wrapper = new TestTaskWrapper(task)
+      action(wrapper)
+    }
+  } else {
+    taskCollection
+      .collect { new TestTaskWrapper(it) }
+      .each(action)
+  }
+}
+
 public class DependencyBasedTestRun {
 
   def logger
@@ -156,12 +169,9 @@ public class TeamcityPropertiesListener implements ProjectEvaluationListener {
   private void loadTestJvmArgs(Project project) {
     final String jvmargs = (String) project.teamcity["gradle.test.jvmargs"]
     final String[] arguments = jvmargs == null ? new String[0] : jvmargs.split("\n")
-    project.tasks.withType(TestTaskWrapper.type)
-            .collect { def task -> new TestTaskWrapper(task) }
-            .each { TestTaskWrapper task ->
-              task.setTmpDirectory(project.teamcity["teamcity.build.tempDir"])
-                      .jvmArgs(arguments)
-            }
+    forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper task ->
+      task.setTmpDirectory(project.teamcity["teamcity.build.tempDir"]).jvmArgs(arguments)
+    }
   }
 
 
@@ -837,17 +847,15 @@ gradle.useLogger(new TeamcityTaskListener(logger, isParallelExec))
 gradle.projectsEvaluated { Gradle gradle ->
   new DependencyBasedTestRun(logger).configureGradle(gradle)
   gradle.rootProject.allprojects { Project project ->
-    project.tasks.withType(TestTaskWrapper.type)
-            .collect { new TestTaskWrapper(it) }
-            .each { TestTaskWrapper testTask ->
-              def testListener = new TeamcityTestListener(logger, testTask, isParallelExec, project, testCounter)
-              testTask.addTestListener(testListener.testListenerDelegate as TestListener)
-              if (testOutputListenerClass != null) {
-                testTask.addTestOutputListener(testListener.testOutputDelegate.asType(testOutputListenerClass))
-                testListener.skipStdOut = Boolean.valueOf(System.properties["teamcity.ignoreTestStdOut"])
-                testListener.skipStdErr = Boolean.valueOf(System.properties["teamcity.ignoreTestStdErr"])
-              }
-            }
+    forAllTestTasks(project.tasks.withType(TestTaskWrapper.type)) { TestTaskWrapper testTask ->
+      def testListener = new TeamcityTestListener(logger, testTask, isParallelExec, project, testCounter)
+      testTask.addTestListener(testListener.testListenerDelegate as TestListener)
+      if (testOutputListenerClass != null) {
+        testTask.addTestOutputListener(testListener.testOutputDelegate.asType(testOutputListenerClass))
+        testListener.skipStdOut = Boolean.valueOf(System.properties["teamcity.ignoreTestStdOut"])
+        testListener.skipStdErr = Boolean.valueOf(System.properties["teamcity.ignoreTestStdErr"])
+      }
+    }
   }
 
   gradle.rootProject.allprojects.each { project ->


### PR DESCRIPTION
In Gradle, if you need one task to depend upon another task in another project, the best way to make this all work is to use lazy evaluation when you declare and configure your tasks. If you force eager evaluation, Gradle can sometimes fail to have all of the tasks created it needs to fully create the task graph. Due to TeamCity forcing eager evaluation for all tasks when they are run with the TC runner, Gradle builds end up failing.

https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

Unfortunately, I don't really have any good way to test that this actually works, so there may be a bug in this implementation. However, the fundamental idea is correct here.

This is to fix an issue where my Gradle builds normally succeed on my local machine, but they fail because TeamCity forces an eager evaluation of the `Test` tasks.