### PR TITLE
Fix local environment variable missing

### DIFF
--- a/gradle-runner-agent/src/main/scripts/init.gradle
+++ b/gradle-runner-agent/src/main/scripts/init.gradle
@@ -773,7 +773,9 @@ public class TeamcityRerunTestsListener extends  BuildAdapter {
 
   @Override
   void projectsEvaluated(Gradle gradle) {
-    defaultOption = System.getenv(GradleRunnerConstants.ENV_SUPPORT_TEST_RETRY).toBoolean();
+    def envOption = System.getenv(GradleRunnerConstants.ENV_SUPPORT_TEST_RETRY)
+    envOption = envOption == null ? "false" : envOption
+    defaultOption = envOption.toBoolean()
     if (defaultOption == true) return
     def conf = config.get()
     if (conf != null && conf[GradleRunnerConstants.GRADLE_USE_TEST_RETRY_PLUGIN] == "false") return


### PR DESCRIPTION
when missing 'TEAMCITY_SUPPORT_TEST_RETRY' project will build failed